### PR TITLE
Add ^ and $ assertions

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,8 @@ pub enum SyntaxErrorKind {
     UnmatchedParen,
     UnknownEscape,
     EmptyRegex,
+    HatAssertPosition,
+    DollarAssertPosition,
 }
 
 #[derive(Debug)]
@@ -42,6 +44,8 @@ impl From<SyntaxError> for Error {
             SyntaxErrorKind::UnmatchedParen => "unmatched parenthesis",
             SyntaxErrorKind::UnknownEscape => "unknown escape sequence",
             SyntaxErrorKind::EmptyRegex => "empty regex",
+            SyntaxErrorKind::HatAssertPosition => "hat assertion can only occur at the beginning",
+            SyntaxErrorKind::DollarAssertPosition => "dollar assertion can only occur at the end",
         }))
     }
 }


### PR DESCRIPTION
Now the parse() function returns a Parsed struct that tells the compiler if the regex contains ^ or $ assertions. Two new instructions are added to the VM to check if the assertions holds.

Solves #6 