### PR TITLE
Feature/greedy

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -14,10 +14,11 @@ pub const HOLE: Iaddr = -1;
 #[derive(PartialEq)]
 pub enum Inst {
     Match,
-    // Avoid increasing the size of enum with `Assert(usize)`
+    // Avoid increasing the size of enum with `Assert(usize)`.
     AssertHat,
     AssertDollar,
     Char(char),
+    // The first branch has higher priority.
     Split(Iaddr, Iaddr),
     Jump(Iaddr),
     Save(u8),
@@ -75,19 +76,9 @@ impl Compiler {
 
     fn fill(&mut self, hole: Iaddr, addr: Iaddr) {
         match self.prog.insts[hole as usize] {
-            Inst::Split(ref mut x, ref mut y) => {
-                if *x == HOLE {
-                    *x = addr;
-                }
-                if *y == HOLE {
-                    *y = addr;
-                }
-            },
-            Inst::Jump(ref mut x) => {
-                if *x == HOLE {
-                    *x = addr;
-                }
-            },
+            Inst::Split(ref mut x, _) if *x == HOLE => *x = addr,
+            Inst::Split(_, ref mut y) if *y == HOLE => *y = addr,
+            Inst::Jump(ref mut x) => *x = addr,
             _ => (),
         }
     }
@@ -97,8 +88,13 @@ impl Compiler {
         Ok(Patch { entry: iaddr, holes: vec![] })
     }
 
-    fn compile_star(&mut self, ast: &Ast) -> Result<Patch, Error> {
-        let inst = Inst::Split(self.next_iaddr() + 1, HOLE);
+    fn compile_star(&mut self, ast: &Ast, greedy: bool) -> Result<Patch, Error> {
+        let inst = if greedy {
+            Inst::Split(self.next_iaddr() + 1, HOLE)
+        }
+        else {
+            Inst::Split(HOLE, self.next_iaddr() + 1)
+        };
         let split = self.emit(inst);
         let patch = self.compile_ast(ast)?;
         let jump = self.emit(Inst::Jump(split));
@@ -108,22 +104,32 @@ impl Compiler {
         Ok(Patch { entry: split, holes: vec![split] })
     }
 
-    fn compile_question(&mut self, ast: &Ast) -> Result<Patch, Error> {
-        let inst = Inst::Split(self.next_iaddr() + 1, HOLE);
+    fn compile_plus(&mut self, ast: &Ast, greedy: bool) -> Result<Patch, Error> {
+        let patch = self.compile_ast(ast)?;
+        let split = if greedy {
+            self.emit(Inst::Split(patch.entry, HOLE))
+        }
+        else {
+            self.emit(Inst::Split(HOLE, patch.entry))
+        };
+        for hole in patch.holes {
+            self.fill(hole, split);
+        }
+        Ok(Patch { entry: patch.entry, holes: vec![split] })
+    }
+
+    fn compile_question(&mut self, ast: &Ast, greedy: bool) -> Result<Patch, Error> {
+        let inst = if greedy {
+            Inst::Split(self.next_iaddr() + 1, HOLE)
+        }
+        else {
+            Inst::Split(HOLE, self.next_iaddr() + 1)
+        };
         let split = self.emit(inst);
         let mut patch = self.compile_ast(ast)?;
         patch.entry = split;
         patch.holes.push(split);
         Ok(patch)
-    }
-
-    fn compile_plus(&mut self, ast: &Ast) -> Result<Patch, Error> {
-        let patch = self.compile_ast(ast)?;
-        let split = self.emit(Inst::Split(patch.entry, HOLE));
-        for hole in patch.holes {
-            self.fill(hole, split);
-        }
-        Ok(Patch { entry: patch.entry, holes: vec![split] })
     }
 
     // ast | ...
@@ -199,9 +205,9 @@ impl Compiler {
             &Ast::Char(c) => self.compile_char(c),
             &Ast::Rep(ref rep) => {
                 match rep.kind {
-                    RepKind::Star => self.compile_star(&rep.ast),
-                    RepKind::Plus => self.compile_plus(&rep.ast),
-                    RepKind::Question => self.compile_question(&rep.ast),
+                    RepKind::Star => self.compile_star(&rep.ast, rep.greedy),
+                    RepKind::Plus => self.compile_plus(&rep.ast, rep.greedy),
+                    RepKind::Question => self.compile_question(&rep.ast, rep.greedy),
                 }
             },
             &Ast::Alter(ref r) => self.compile_alter(r),
@@ -309,14 +315,33 @@ mod tests {
             i!(match)
         });
 
+        assert_compile!(Parser::parse(r"a*?").unwrap(), p! {
+            i!(split 3, 1),
+            i!(char 'a'),
+            i!(jump 0),
+            i!(match)
+        });
+
         assert_compile!(Parser::parse(r"a+").unwrap(), p! {
             i!(char 'a'),
             i!(split 0, 2),
             i!(match)
         });
 
+        assert_compile!(Parser::parse(r"a+?").unwrap(), p! {
+            i!(char 'a'),
+            i!(split 2, 0),
+            i!(match)
+        });
+
         assert_compile!(Parser::parse(r"a?").unwrap(), p! {
             i!(split 1, 2),
+            i!(char 'a'),
+            i!(match)
+        });
+
+        assert_compile!(Parser::parse(r"a??").unwrap(), p! {
+            i!(split 2, 1),
             i!(char 'a'),
             i!(match)
         });

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,6 +1,6 @@
 use ::GROUP_MAX;
 use error::Error;
-use parse::{Ast, Parsed};
+use parse::{Ast, RepKind, Parsed};
 use std::fmt;
 
 // It should be usize to be theoretically correct,
@@ -14,7 +14,7 @@ pub const HOLE: Iaddr = -1;
 #[derive(PartialEq)]
 pub enum Inst {
     Match,
-    // Putting an `Assert(usize)` here will increase the size of `Inst`.
+    // Avoid increasing the size of enum with `Assert(usize)`
     AssertHat,
     AssertDollar,
     Char(char),
@@ -197,9 +197,13 @@ impl Compiler {
     fn compile_ast(&mut self, ast: &Ast) -> Result<Patch, Error> {
         match ast {
             &Ast::Char(c) => self.compile_char(c),
-            &Ast::Star(ref r) => self.compile_star(r),
-            &Ast::Plus(ref r) => self.compile_plus(r),
-            &Ast::Question(ref r) => self.compile_question(r),
+            &Ast::Rep(ref rep) => {
+                match rep.kind {
+                    RepKind::Star => self.compile_star(&rep.ast),
+                    RepKind::Plus => self.compile_plus(&rep.ast),
+                    RepKind::Question => self.compile_question(&rep.ast),
+                }
+            },
             &Ast::Alter(ref r) => self.compile_alter(r),
             &Ast::Concat(ref r) => self.compile_concat(r),
             &Ast::Group(idx, ref r) => self.compile_group(idx, r),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -18,6 +18,7 @@ pub struct Vm<'a> {
     // one `pc` for a certain string index, because the execution
     // will be the same.
     visited: Vec<usize>,
+    found_match: bool,
 }
 
 impl<'a> Vm<'a> {
@@ -26,40 +27,54 @@ impl<'a> Vm<'a> {
             prog,
             groups: Groups::default(),
             visited: vec![0; prog.insts.len()],
+            found_match: false,
         }
     }
 
-    fn catch_up(&mut self, mut th: Thread, si: usize, slen: usize, list: &mut Vec<Thread>) {
+    fn epsilon(&mut self,
+               mut th: Thread,
+               si: usize,
+               slen: usize,
+               list: &mut Vec<Thread>)
+            -> bool {
         // The recursion here needs more love. Should be done with a stack.
         if si + 1 == self.visited[th.pc as usize] {
-            return;
+            return false;
         }
         self.visited[th.pc as usize] = si + 1;
 
         match self.prog.insts[th.pc as usize] {
+            Inst::Match => {
+                th.groups[0] = Some(Group { begin: 0, end: si });
+                self.groups = th.groups.clone();
+                self.found_match = true;
+                true
+            },
             Inst::AssertHat => {
                 if si != 0 {
-                    return;
+                    return false;
                 }
                 th.pc += 1;
-                self.catch_up(th, si, slen, list);
+                self.epsilon(th, si, slen, list)
             },
             Inst::AssertDollar => {
                 if si != slen {
-                    return;
+                    return false;
                 }
                 th.pc += 1;
-                self.catch_up(th, si, slen, list);
+                self.epsilon(th, si, slen, list)
             },
             Inst::Jump(iaddr) => {
                 th.pc = iaddr;
-                self.catch_up(th, si, slen, list);
+                self.epsilon(th, si, slen, list)
             },
             Inst::Split(iaddr1, iaddr2) => {
                 th.pc = iaddr1;
-                self.catch_up(th.clone(), si, slen, list);
+                if self.epsilon(th.clone(), si, slen, list) {
+                    return true;
+                }
                 th.pc = iaddr2;
-                self.catch_up(th, si, slen, list);
+                self.epsilon(th, si, slen, list)
             },
             Inst::Save(groupidx) => {
                 let g = groupidx / 2;
@@ -72,10 +87,11 @@ impl<'a> Vm<'a> {
                     }
                 }
                 th.pc += 1;
-                self.catch_up(th, si, slen, list);
+                self.epsilon(th, si, slen, list)
             },
             _ => {
                 list.push(th);
+                false
             },
         }
     }
@@ -88,25 +104,27 @@ impl<'a> Vm<'a> {
 
         let slen = s.len();
 
+        // We should get rid of this unsafe.
         unsafe {
             let mut si = 0;
-            self.catch_up(Thread { pc: 0, groups: Groups::default() }, si, slen, &mut *curr);
+            self.epsilon(Thread { pc: 0, groups: Groups::default() }, si, slen, &mut *curr);
 
             while !(*curr).is_empty() {
                 for th in (*curr).iter_mut() {
                     match &self.prog.insts[th.pc as usize] {
-                        &Inst::Match => {
-                            th.groups[0] = Some(Group { begin: 0, end: s.len() });
-                            self.groups = th.groups.clone();
-                            return true;
-                        },
                         &Inst::Char(c) => {
                             if si < s.len() && s[si] == c {
                                 th.pc += 1;
-                                self.catch_up(*th, si + 1, slen, &mut *next);
+                                if self.epsilon(*th, si + 1, slen, &mut *next) {
+                                    break;
+                                }
                             }
                         },
-                        _ => self.catch_up(*th, si, slen, &mut *next),
+                        _ => {
+                            if self.epsilon(*th, si, slen, &mut *next) {
+                                break;
+                            }
+                        },
                     }
                 }
                 (*curr).clear();
@@ -118,7 +136,7 @@ impl<'a> Vm<'a> {
             }
         }
 
-        false
+        self.found_match
     }
 }
 
@@ -149,7 +167,6 @@ mod tests {
             assert!(vm.run(&$s.chars().collect()));
 
             let mut expected = Groups::default();
-            expected[0] = Some(Group { begin: 0, end: $s.len() });
             for (groupidx, begin, end) in vec![$(($groupidx, $begin, $end)),+] {
                 expected[groupidx] = Some(Group { begin, end });
             }
@@ -184,16 +201,23 @@ mod tests {
         assert_match!(r"(a|b)*d+(ef)?", "addef");
         assert_match!(r"(a|b)*d+(ef)?", "bddef");
         assert_match!(r"(a|b)*d+(ef)?", "aabbaddef");
-
+        // Hat, dollar assersions
         assert_match!(r"^abc", "abcdefg");
         assert_match!(r"a*$", "aaaaaaa");
         assert_match!(r"^a*$", "aaaaaaa");
-
-        assert_match_groups!(r"(a)", "a", (1, 0, 1));
-        assert_match_groups!(r"(a)(b)", "ab", (1, 0, 1), (2, 1, 2));
-        assert_match_groups!(r"(a|b)+d", "abaabd", (1, 4, 5));
-        assert_match_groups!(r"(a(b(c)))d", "abcd", (1, 0, 3), (2, 1, 3), (3, 2, 3));
-        assert_match_groups!(r"(a(b)|c(d))e", "cde", (1, 0, 2), (3, 1, 2));
+        // Greedy, non-greedy
+        assert_match_groups!(r"a*", "aaa", (0, 0, 3));
+        assert_match_groups!(r"a*?", "aaa", (0, 0, 0));
+        assert_match_groups!(r"a+", "aaa", (0, 0, 3));
+        assert_match_groups!(r"a+?", "aaa", (0, 0, 1));
+        assert_match_groups!(r"a?", "aaa", (0, 0, 1));
+        assert_match_groups!(r"a??", "aaa", (0, 0, 0));
+        // Capturing groups
+        assert_match_groups!(r"(a)", "a", (0, 0, 1), (1, 0, 1));
+        assert_match_groups!(r"(a)(b)", "ab", (0, 0, 2), (1, 0, 1), (2, 1, 2));
+        assert_match_groups!(r"(a|b)+d", "abaabd", (0, 0, 6), (1, 4, 5));
+        assert_match_groups!(r"(a(b(c)))d", "abcd", (0, 0, 4), (1, 0, 3), (2, 1, 3), (3, 2, 3));
+        assert_match_groups!(r"(a(b)|c(d))e", "cde", (0, 0, 3), (1, 0, 2), (3, 1, 2));
 
         // The bad
         assert_not_match!(r"a", "b");


### PR DESCRIPTION
Previously when we follow epsilon transitions on `Split` instructions, we recurse on the first branch and then recurse on the second. In this way all the next PC positions are pushed onto the next list, so the match is always greedy.

Now for non-greedy repetitions, if we find a match when recursing on the first branch, we return immediately to keep conservative.

We stop iterating on the `curr` and `next` lists until there's no more recorded PCs in the `curr` list.

So for greedy repetitions there will always be something to look at since we try the repetition first thus it comes before the non-greedy possibilities on the `next` list. But for non-greedy repetitions, since we early stop following epsilon transitions, the other branch, the greedy one, will not be tried at all thus it won't appear in `next` list.