### PR TITLE
Add character set matching

### DIFF
--- a/src/charset.rs
+++ b/src/charset.rs
@@ -1,0 +1,91 @@
+use std::{cmp, fmt};
+
+#[derive(Copy, Clone)]
+pub struct Charset {
+    set: [bool; 128],
+}
+
+impl fmt::Debug for Charset {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "[")?;
+        for c in 0x00_u8 .. 0x80_u8 {
+            if self.set[c as usize] {
+                write!(f, "{}", c as char)?;
+            }
+        }
+        write!(f, "]")
+    }
+}
+
+impl cmp::PartialEq for Charset {
+    fn eq(&self, other: &Charset) -> bool {
+        for i in 0..self.set.len() {
+            if self.set[i] != other.set[i] {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl Charset {
+    pub fn new() -> Self {
+        Charset { set: [false; 128] }
+    }
+
+    pub fn from_chars(chars: &[char]) -> Self {
+        let mut cs = Charset { set: [false; 128] };
+        for c in chars {
+            cs.add(*c);
+        }
+        cs
+    }
+
+    pub fn from_chars_complement(chars: &[char]) -> Self {
+        let mut cs = Charset { set: [false; 128] };
+        for c in chars {
+            cs.add(*c);
+        }
+        cs.complement();
+        cs
+    }
+
+    pub fn add(&mut self, c: char) -> bool {
+        if !c.is_ascii() || c.len_utf8() != 1 {
+            return false;
+        }
+        self.set[c as usize] = true;
+        true
+    }
+
+    pub fn has(&self, c: char) -> bool {
+        if !c.is_ascii() || c.len_utf8() != 1 {
+            return false;
+        }
+        self.set[c as usize]
+    }
+
+    pub fn complement(&mut self) {
+        for x in self.set.iter_mut() {
+            *x = !*x;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_charset_acsii() {
+        let mut cs = Charset::new();
+        for c in 0x00_u8 .. 0x80_u8 {
+            assert!(cs.add(c as char));
+            assert!(cs.has(c as char));
+        }
+        assert!(!cs.add('虎'));
+        assert!(!cs.has('虎'));
+        assert!(!cs.add(0xfe as char));
+        assert!(!cs.has(0xfe as char));
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,9 @@ pub enum SyntaxErrorKind {
     HatAssertPosition,
     DollarAssertPosition,
     UnknownGroupExt,
+    NonAsciiNotSupported,
+    UnterminatedCharset,
+    InvalidCharacterRange,
 }
 
 #[derive(Debug)]
@@ -48,6 +51,9 @@ impl From<SyntaxError> for Error {
             SyntaxErrorKind::HatAssertPosition => "hat assertion can only occur at the beginning",
             SyntaxErrorKind::DollarAssertPosition => "dollar assertion can only occur at the end",
             SyntaxErrorKind::UnknownGroupExt => "unknown capturing group extension",
+            SyntaxErrorKind::NonAsciiNotSupported => "non ascii characters are not supported",
+            SyntaxErrorKind::UnterminatedCharset => "unterminated character set",
+            SyntaxErrorKind::InvalidCharacterRange => "invalid character range",
         }))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
-mod error;
-mod parse;
-mod compile;
-mod vm;
+pub mod charset;
+pub mod error;
+pub mod parse;
+pub mod compile;
+pub mod vm;
 
 use error::Error;
 use vm::Vm;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -134,6 +134,14 @@ impl<'a> Vm<'a> {
                             }
                         }
                     }
+                    &Inst::Charset(ref cs) => {
+                        if sidx < s.len() && cs.has(s[sidx]) {
+                            t.pc += 1;
+                            if self.epsilon(t, sidx + 1, slen, &mut next) {
+                                break;
+                            }
+                        }
+                    }
                     _ => {
                         if self.epsilon(t, sidx, slen, &mut next) {
                             break;
@@ -220,6 +228,14 @@ mod tests {
         assert_match!(r"^a*$", "aaaaaaa");
         assert_match!(r"^...$", "aaa");
         assert_match!(r"aaa", "xxxxxaaaxxxxx");
+        assert_match!(r"[abc]", "a");
+        assert_match!(r"[^abc]", "x");
+        assert_match!(r"[a-c][a-c][a-c]", "abc");
+        assert_match!(r"^[-c]+$", "c--");
+        assert_match!(r"[a^c]", "^");
+        assert_match!(r"[-]", "-");
+        assert_match!(r"^[a-zA-Z0-9. ]+$", "Of course I still love you.");
+        assert_match!(r"^[a-zA-Z0-9. ]+$", "Just read the instructions.");
 
         assert_match_groups!(r"a*", "aaa", (0, 0, 3));
         assert_match_groups!(r"a*?", "aaa", (0, 0, 0));


### PR DESCRIPTION
Right now we only support ASCII characters. This completes the first stage of #25.