### PR TITLE
Add counted repetition

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,7 @@ pub enum SyntaxErrorKind {
     NonAsciiNotSupported,
     UnterminatedCharset,
     InvalidCharacterRange,
+    InvalidCountedRepetition,
 }
 
 #[derive(Debug)]
@@ -54,6 +55,7 @@ impl From<SyntaxError> for Error {
             SyntaxErrorKind::NonAsciiNotSupported => "non ascii characters are not supported",
             SyntaxErrorKind::UnterminatedCharset => "unterminated character set",
             SyntaxErrorKind::InvalidCharacterRange => "invalid character range",
+            SyntaxErrorKind::InvalidCountedRepetition => "invalid counted repetition",
         }))
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -236,6 +236,22 @@ mod tests {
         assert_match!(r"[-]", "-");
         assert_match!(r"^[a-zA-Z0-9. ]+$", "Of course I still love you.");
         assert_match!(r"^[a-zA-Z0-9. ]+$", "Just read the instructions.");
+        assert_match!(r"^a{3}$", "aaa");
+        assert_match!(r"^a{3,}$", "aaa");
+        assert_match!(r"^a{3,}$", "aaaaaaa");
+        assert_match!(r"^a{,3}$", "");
+        assert_match!(r"^a{,3}$", "a");
+        assert_match!(r"^a{,3}$", "aaa");
+        assert_match!(r"^a{3,3}$", "aaa");
+        assert_match!(r"^a{3,5}$", "aaa");
+        assert_match!(r"^a{3,5}$", "aaaa");
+        assert_match!(r"^a{3,5}$", "aaaaa");
+        assert_match!(r"^a{,}$", "");
+        assert_match!(r"^a{,}$", "a");
+        assert_match!(r"^a{,}$", "a");
+        assert_match!(r"^[0-9a-zA-Z]{3,5}$", "0xA");
+        assert_match!(r"^[0-9a-zA-Z]{3,5}$", "0xab");
+        assert_match!(r"^[0-9a-zA-Z]{3,5}$", "0xa1b");
 
         assert_match_groups!(r"a*", "aaa", (0, 0, 3));
         assert_match_groups!(r"a*?", "aaa", (0, 0, 0));
@@ -260,6 +276,10 @@ mod tests {
                                                           (3, 0, 1), (4, 0, 1), (5, 0, 1),
                                                           (6, 0, 1), (7, 0, 1), (8, 0, 1),
                                                           (9, 0, 1));
+        assert_match_groups!(r"a{3,}?", "aaaaaaa", (0, 0, 3));
+        assert_match_groups!(r"a{3,5}?", "aaa", (0, 0, 3));
+        assert_match_groups!(r"a{3,5}?", "aaaa", (0, 0, 3));
+        assert_match_groups!(r"a{3,5}?", "aaaaa", (0, 0, 3));
 
         // The bad
         assert_not_match!(r"a", "b");
@@ -271,5 +291,9 @@ mod tests {
         assert_not_match!(r"aaa$", "aaaxxxxx");
         assert_not_match!(r"^aaa", "xxxxxaaa");
         assert_not_match!(r"aaa", "xxxxxaaxxxx");
+        assert_not_match!(r"a{3}", "aa");
+        assert_not_match!(r"a{3,5}", "a");
+        assert_not_match!(r"a{3,5}", "aa");
+        assert_not_match!(r"^a{3,5}$", "aaaaaa");
     }
 }


### PR DESCRIPTION
At first I was doing this by keeping a variable in each thread that counts how many times we have repeated, but that will only work as long as we have only one level of repetition, meaning that it cannot handle repetitions like `(a{3,5})+`. Also that will introduce 3 or 4 new instructions to increase the repetition count, to jump conditionally to a place depending on the the comparison result of the thread repetition count and the required ones.

So I just follow the popular strategy of implementing this, by rewriting counted repetitions with existing ones. `a{2,4}` will be rewritten as `aa(aa?)?`.

This will be slow, since the repeated part may be something big, and the chain of `?`s will result in a lot of `Split` instructions in the compiled code.

Closes #27 